### PR TITLE
fix use of mpi_family() in ALADIN, Intel MKL and NWChem easyblocks, w.r.t. MPICH family

### DIFF
--- a/easybuild/easyblocks/a/aladin.py
+++ b/easybuild/easyblocks/a/aladin.py
@@ -158,7 +158,7 @@ class EB_ALADIN(EasyBlock):
             self.log.error("Failed to remove existing file %s: %s" % (self.conf_filepath, err))
 
         mpich = 'n'
-        known_mpi_libs = [toolchain.MPICH2, toolchain.INTELMPI]
+        known_mpi_libs = [toolchain.MPICH, toolchain.MPICH2, toolchain.INTELMPI]
         if self.toolchain.options.get('usempi', None) and self.toolchain.mpi_family() in known_mpi_libs:
             mpich = 'y'
 

--- a/easybuild/easyblocks/e/esmf.py
+++ b/easybuild/easyblocks/e/esmf.py
@@ -61,7 +61,8 @@ class EB_ESMF(ConfigureMake):
         # specify MPI communications library
         comm = None
         mpi_family = self.toolchain.mpi_family()
-        if mpi_family in [toolchain.QLOGICMPI]:
+        if mpi_family in [toolchain.MPICH, toolchain.QLOGICMPI]:
+            # MPICH family for MPICH v3.x, which is MPICH2 compatible
             comm = 'mpich2'
         else:
             comm = mpi_family.lower()

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -40,6 +40,7 @@ import tempfile
 from distutils.version import LooseVersion
 
 import easybuild.tools.environment as env
+import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.filetools import rmtree2, run_cmd
@@ -235,11 +236,29 @@ class EB_imkl(IntelBase):
                 if lib in fftw3libs:
                     buildopts.append('install_to=$INSTALL_DIR')
                 elif lib in cdftlibs:
-                    # can't use toolchain.mpi_family, because of dummy toolchain
-                    if get_software_root('MPICH2') or get_software_root('MVAPICH2'):
-                        buildopts.append('mpi=mpich2')
-                    elif get_software_root('OpenMPI'):
-                        buildopts.append('mpi=openmpi')
+                    mpi_spec = None
+                    # check whether MPI_FAMILY constant is defined, so mpi_family() can be used
+                    if hasattr(self.toolchain, 'MPI_FAMILY') and self.toolchain.MPI_FAMILY is not None:
+                        mpi_spec_by_fam = {
+                            toolchain.MPICH: 'mpich2',  # MPICH is MPICH v3.x, whcih MPICH2 compatible
+                            toolchain.MPICH2: 'mpich2',
+                            toolchain.MVAPICH2: 'mpich2',
+                            toolchain.OPENMPI: 'openmpi',
+                        }
+                        mpi_fam = self.toolchain.mpi_family()
+                        mpi_spec = mpi_spec_by_fam.get(mpi_fam)
+                        self.log.debug("Determined MPI specification based on MPI toolchain component: %s" % mpi_spec)
+                    else:
+                        # can't use toolchain.mpi_family, because of dummy toolchain
+                        if get_software_root('MPICH2') or get_software_root('MVAPICH2'):
+                            mpi_spec = 'mpich2'
+                        elif get_software_root('OpenMPI'):
+                            mpi_spec = 'openmpi'
+                        self.log.debug("Determined MPI specification based on loaded MPI module: %s" % mpi_spec)
+
+                    if mpi_spec is not None:
+                        buildopts.append('mpi=%s' % mpi_spec)
+
                 precflags = ['']
                 if lib.startswith('fftw2x') and not self.cfg['m32']:
                     # build both single and double precision variants

--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -182,7 +182,7 @@ class EB_NWChem(ConfigureMake):
                 libmpi = "-lmpigf -lmpigi -lmpi_ilp64 -lmpi_mt"
             else:
                 libmpi = "-lmpigf -lmpigi -lmpi_ilp64 -lmpi"
-        elif mpi_family in [toolchain.MPICH2]:
+        elif mpi_family in [toolchain.MPICH, toolchain.MPICH2]:
             libmpi = "-lmpich -lopa -lmpl -lrt -lpthread"
         else:
             self.log.error("Don't know how to set LIBMPI for %s" % mpi_family)


### PR DESCRIPTION
to fix other easyblocks, see https://github.com/hpcugent/easybuild-easyblocks/pull/519
