### PR TITLE
cleanup, fixes and enhancements to SystemCompiler easyblock

### DIFF
--- a/easybuild/easyblocks/generic/systemcompiler.py
+++ b/easybuild/easyblocks/generic/systemcompiler.py
@@ -39,7 +39,14 @@ from easybuild.tools.build_log import EasyBuildError
 
 
 class SystemCompiler(Bundle):
-    """Create EasyBuild 'dummy' module for system compiler."""
+    """
+    Support for generating a module file for the system compiler with specified name.
+
+    The compiler is expected to be available in $PATH, required libraries are assumed to be readily available.
+
+    Specifying 'system' as a version leads to using the derived compiler version in the generated module;
+    if an actual version is specified, it is checked against the derived version of the system compiler that was found.
+    """
 
     def extract_compiler_version(self, txt):
         """Extract compiler version from provided string."""

--- a/easybuild/easyblocks/generic/systemcompiler.py
+++ b/easybuild/easyblocks/generic/systemcompiler.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2015 Ghent University
+# Copyright 2015-2015 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -32,7 +32,7 @@ import os
 import re
 
 from easybuild.easyblocks.generic.bundle import Bundle
-from easybuild.tools.filetools import which
+from easybuild.tools.filetools import read_file, which
 from easybuild.tools.run import run_cmd
 from easybuild.framework.easyconfig.easyconfig import ActiveMNS
 from easybuild.tools.build_log import EasyBuildError
@@ -41,100 +41,101 @@ from easybuild.tools.build_log import EasyBuildError
 class SystemCompiler(Bundle):
     """Create EasyBuild 'dummy' module for system compiler."""
 
-    #
-    # INIT
-    #
+    def extract_compiler_version(self, txt):
+        """Extract compiler version from provided string."""
+        # look for 3-4 digit version number, surrounded by spaces
+        # examples:
+        # gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-11)
+        # Intel(R) C Intel(R) 64 Compiler XE for applications running on Intel(R) 64, Version 15.0.1.133 Build 20141023
+        version_regex = re.compile(r'\s([0-9]+(?:\.[0-9]+){1,3})\s', re.M)
+        res = version_regex.search(txt)
+        if res:
+            self.compiler_version = res.group(1)
+            self.log.debug("Extracted compiler version '%s' from: %s", self.compiler_version, txt)
+        else:
+            raise EasyBuildError("Failed to extract compiler version using regex pattern '%s' from: %s",
+                                 version_regex.pattern, txt)
+
     def __init__(self, *args, **kwargs):
         """Extra initialization: determine system compiler version and prefix."""
         super(SystemCompiler, self).__init__(*args, **kwargs)
 
-        # Determine compiler path
-        self.compiler_name = self.cfg['name'].lower()
-        path_to_compiler = which(self.compiler_name)
+        # Determine compiler path (real path, with resolved symlinks)
+        compiler_name = self.cfg['name'].lower()
+        path_to_compiler = os.path.realpath(which(compiler_name))
         if path_to_compiler is None:
-            raise EasyBuildError("%s not in $PATH" % self.compiler_name)
+            raise EasyBuildError("%s not in $PATH", compiler_name)
 
-        # Determine compiler version and prefix
-        if self.compiler_name == 'gcc':
-            out, _ = run_cmd('gcc --version', simple=False)
-            self.compiler_version = re.findall("([0-9]+(?:\.[0-9]+){1,3})", out)[0]
-            # strip off "gcc" and "bin"
+        # Determine compiler version and installation prefix
+        if compiler_name == 'gcc':
+            out, _ = run_cmd("gcc --version", simple=False)
+            self.extract_compiler_version(out)
+
+            # strip off 'bin/gcc'
             self.compiler_prefix = os.path.dirname(os.path.dirname(path_to_compiler))
-            self.cfg['homepage'] = "http://gcc.gnu.org/"
 
-        elif self.compiler_name == 'icc' or self.compiler_name == 'ifort':
-            out, _ = run_cmd('icc -V', simple=False)
-            self.compiler_version = re.findall("([0-9]+(?:\.[0-9]+){1,3})", out)[0]
+        elif compiler_name in ['icc', 'ifort']:
+            out, _ = run_cmd("%s -V" % compiler_name, simple=False)
+            self.extract_compiler_version(out)
 
-            intelvars_fn = path_to_compiler + "vars.sh"
-            prefix = None
+            intelvars_fn = path_to_compiler + 'vars.sh'
             if os.path.isfile(intelvars_fn):
-                for line in open(intelvars_fn, 'r'):
-                     prefix = re.findall("^PROD_DIR=(.*)$", line)
-                     if prefix:
-                        break
-                if prefix:
-                    self.compiler_prefix = prefix[0]
+                self.log.debug("Trying to determine compiler install prefix from %s", intelvars_fn)
+                intelvars_txt = read_file(intelvars_fn)
+                prod_dir_regex = re.compile(r'^PROD_DIR=(.*)$', re.M)
+                res = prod_dir_regex.search(intelvars_txt)
+                if res:
+                    self.compiler_prefix = res.group(1)
                 else:
-                    raise EasyBuildError("Cannot determine %s prefix" % self.compiler_name)
+                    raise EasyBuildError("Failed to determine %s installation prefix from %s",
+                                          compiler_name, intelvars_fn)
             else:
-                # strip off "icc", "intel*" and "bin"
-                self.compiler_prefix = os.path.dirname(os.path.dirname(os.path.dirname(path_to_icc)))
-            self.cfg['homepage'] = "http://software.intel.com/en-us/intel-compilers/"
+                # strip off 'bin/intel*/icc'
+                self.compiler_prefix = os.path.dirname(os.path.dirname(os.path.dirname(path_to_compiler)))
 
         else:
             raise EasyBuildError("Unknown system compiler %s" % self.cfg['name'])
 
+        self.log.debug("Derived version/install prefix for system compiler %s: %s, %s",
+                       compiler_name, self.compiler_version, self.compiler_prefix)
+
         # If EasyConfig specified "real" version (not 'system' which means 'derive automatically'), check it
-        if self.cfg['version'] != 'system' and self.cfg['version'] != self.compiler_version:
+        if self.cfg['version'] == 'system':
+            self.log.info("Found specified version '%s', going with derived compiler version '%s'",
+                          self.cfg['version'], self.compiler_version)
+        elif self.cfg['version'] != self.compiler_version:
             raise EasyBuildError("Specified version (%s) does not match version reported by compiler (%s)" %
                                  (self.cfg['version'], self.compiler_version))
 
-        # Provide suitable default values for system compiler module file
-        default_desc = "EasyBuild wrapper for system compiler %s-%s" % (self.compiler_name, self.compiler_version)
-        if not self.cfg['description']:
-            self.cfg['description'] = default_desc
-
-        # Ensure moduleclass is set correctly
-        self.cfg['moduleclass'] = 'compiler'
-
-        # set and remember EasyBuild installdir (modeled after: easybuild/framework/easyconfig/easyconfig.py)
+        # fix installdir and module names (may differ because of changes to version)
         mns = ActiveMNS()
         self.cfg.full_mod_name = mns.det_full_module_name(self.cfg)
         self.cfg.short_mod_name = mns.det_short_module_name(self.cfg)
         self.cfg.mod_subdir = mns.det_module_subdir(self.cfg)
+
+        # keep track of original values, for restoring later
+        self.orig_version = self.cfg['version']
         self.orig_installdir = self.installdir
 
-    #
-    # DIRECTORY UTILITY FUNCTIONS
-    #
     def make_installdir(self, dontcreate=None):
-        """Custom version: Do not to touch system compiler directories and files."""
+        """Custom implementation of make installdir: do nothing, do not touch system compiler directories and files."""
         pass
 
-    #
-    # MODULE UTILITY FUNCTIONS
-    #
     def make_module_req_guess(self):
         """
         A dictionary of possible directories to look for.  Return empty dict for a system compiler.
         """
         return {}
 
-    #
-    # STEP FUNCTIONS
-    #
     def post_install_step(self):
-        """Custom version: Do not to touch system compiler directories and files."""
+        """Custom post install step: Do not to touch system compiler directories and files."""
         pass
 
     def make_module_step(self, fake=False):
         """Custom module step for SystemCompiler: make 'EBROOT' and 'EBVERSION' reflect system compiler values."""
-        self.orig_version = self.cfg['version']
-
         # For module file generation: temporarly set version and installdir to system compiler values
         self.cfg['version'] = self.compiler_version
-        self.installdir= self.compiler_prefix
+        self.installdir = self.compiler_prefix
 
         # Generate module
         res = super(SystemCompiler, self).make_module_step(fake=fake)

--- a/easybuild/easyblocks/generic/systemcompiler.py
+++ b/easybuild/easyblocks/generic/systemcompiler.py
@@ -62,9 +62,12 @@ class SystemCompiler(Bundle):
 
         # Determine compiler path (real path, with resolved symlinks)
         compiler_name = self.cfg['name'].lower()
-        path_to_compiler = os.path.realpath(which(compiler_name))
-        if path_to_compiler is None:
-            raise EasyBuildError("%s not in $PATH", compiler_name)
+        path_to_compiler = which(compiler_name)
+        if path_to_compiler:
+            path_to_compiler = os.path.realpath(path_to_compiler)
+            self.log.info("Found path to compiler '%s' (with symlinks resolved): %s", compiler_name, path_to_compiler)
+        else:
+            raise EasyBuildError("%s not found in $PATH", compiler_name)
 
         # Determine compiler version and installation prefix
         if compiler_name == 'gcc':

--- a/test/easyblocks/init_easyblocks.py
+++ b/test/easyblocks/init_easyblocks.py
@@ -62,12 +62,12 @@ class InitTest(TestCase):
     config.set_tmpdir()
     del eb_go
 
-    def writeEC(self, easyblock, extratxt=''):
+    def writeEC(self, easyblock, name='foo', version='1.3.2', extratxt=''):
         """ create temporary easyconfig file """
         txt = '\n'.join([
             'easyblock = "%s"',
-            'name = "foo"',
-            'version = "1.3.2"',
+            'name = "%s"' % name,
+            'version = "%s"' % version,
             'homepage = "http://example.com"',
             'description = "Dummy easyconfig file."',
             'toolchain = {"name": "dummy", "version": "dummy"}',
@@ -88,10 +88,10 @@ class InitTest(TestCase):
         try:
             os.remove(self.eb_file)
         except OSError, err:
-            self.log.error("Failed to remove %s/%s: %s" % (self.eb_file, err))
+            self.log.error("Failed to remove %s: %s" % (self.eb_file, err))
 
 
-def template_init_test(self, easyblock):
+def template_init_test(self, easyblock, name='foo', version='1.3.2'):
     """Test whether all easyblocks can be initialized."""
 
     def check_extra_options_format(extra_options):
@@ -141,7 +141,7 @@ def template_init_test(self, easyblock):
                 extra_txt += '%s = "foo"\n' % key
 
         # write easyconfig file
-        self.writeEC(ebname, extra_txt)
+        self.writeEC(ebname, name=name, version=version, extratxt=extra_txt)
 
         # initialize easyblock
         # if this doesn't fail, the test succeeds
@@ -169,6 +169,7 @@ def template_init_test(self, easyblock):
     else:
         self.assertTrue(False, "Class found in easyblock %s" % easyblock)
 
+
 def suite():
     """Return all easyblock initialisation tests."""
 
@@ -179,7 +180,12 @@ def suite():
 
     for easyblock in easyblocks:
         # dynamically define new inner functions that can be added as class methods to InitTest
-        exec("def innertest(self): template_init_test(self, '%s')" % easyblock)
+        if os.path.basename(easyblock) == 'systemcompiler.py':
+            # use GCC as name when testing SystemCompiler easyblock
+            exec("def innertest(self): template_init_test(self, '%s', name='GCC', version='system')" % easyblock)
+        else:
+            exec("def innertest(self): template_init_test(self, '%s')" % easyblock)
+
         innertest.__doc__ = "Test for initialisation of easyblock %s" % easyblock
         innertest.__name__ = "test_easyblock_%s" % '_'.join(easyblock.replace('.py', '').split('/'))
         setattr(InitTest, innertest.__name__, innertest)

--- a/test/easyblocks/module_only.py
+++ b/test/easyblocks/module_only.py
@@ -171,8 +171,9 @@ def suite():
     all_pys = glob.glob('%s/*/*.py' % easyblocks_path)
     easyblocks = [eb for eb in all_pys if os.path.basename(eb) != '__init__.py' and '/test/' not in eb]
 
-    # filter out no longer supported easyblocks
-    easyblocks = [e for e in easyblocks if os.path.basename(e) not in ['versionindependendpythonpackage.py']]
+    # filter out no longer supported easyblocks, or easyblocks that are tested in a different way
+    excluded_easyblocks = ['systemcompiler.py', 'versionindependendpythonpackage.py']
+    easyblocks = [e for e in easyblocks if os.path.basename(e) not in excluded_easyblocks]
 
     for easyblock in easyblocks:
         # dynamically define new inner functions that can be added as class methods to ModuleOnlyTest


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyblocks/pull/633

I tested the various 'use cases', all working fine:
- generating module for system GCC using `'system'` version, yields `GCC/system` module and finds system compiler version as intended
- generating module for system GCC using specified version, yields corresponding module or reports an error if versions don't match
- generating module for system icc, finds system compiler version as intended
